### PR TITLE
Fix composer/installers version constraint to support latest release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
     "php": ">=5.3.2",
-    "composer/installers": "~1.2.0"
+    "composer/installers": "^1.2"
   },
   "require-dev": {
     "inpsyde/php-coding-standards": "^0.12"


### PR DESCRIPTION
Currently the version constraint doesn't allow bumping to 1.3 and the latest release is currently at 1.5. This will support updates as far as <2.0.0