### PR TITLE
Fix missing site id, warnings and sets new default site id

### DIFF
--- a/multisite-global-media.php
+++ b/multisite-global-media.php
@@ -244,9 +244,9 @@ add_action( 'save_post', __NAMESPACE__ . '\save_thumbnail_meta', 99);
 function save_thumbnail_meta($post_id) {
 
     $id_prefix = get_site_id() . '00000';
-    if ($_POST['_thumbnail_id'] && false !== strpos($_POST['_thumbnail_id'], $id_prefix)) {
-        update_post_meta($post_id, '_thumbnail_id', $_POST['_thumbnail_id']);
-        update_post_meta($post_id, 'global_media_site_id', get_site_id());
+    if ( ! empty( $_POST['_thumbnail_id'] ) && false !== strpos( $_POST['_thumbnail_id'], $id_prefix ) ) {
+        update_post_meta( $post_id, '_thumbnail_id', intval( $_POST['_thumbnail_id'] ) );
+        update_post_meta( $post_id, 'global_media_site_id', get_site_id() );
     }
 
 }

--- a/multisite-global-media.php
+++ b/multisite-global-media.php
@@ -5,7 +5,7 @@
  * Description: Multisite Global Media is a WordPress plugin which shares media across the Multisite network.
  * Network:     true
  * Plugin URI:  https://github.com/bueltge/multisite-global-media
- * Version:     0.0.5
+ * Version:     0.0.6
  * Author:      Dominik Schilling, Frank Bültge
  * License:     MIT
  * License URI: ./LICENSE

--- a/multisite-global-media.php
+++ b/multisite-global-media.php
@@ -37,7 +37,7 @@ defined('ABSPATH') || die();
  * @var    integer
  * @since  2015-01-22
  */
-const SITE_ID = 3;
+const SITE_ID = 1;
 
 /**
  * Return the ID of site that store the media files.

--- a/multisite-global-media.php
+++ b/multisite-global-media.php
@@ -294,8 +294,12 @@ add_filter( 'admin_post_thumbnail_html', __NAMESPACE__ . '\admin_post_thumbnail_
      */
 
 function admin_post_thumbnail_html ( $content, $post_id, $thumbnail_id ) {
-// var_dump(get_post_meta( $post_id));
+
     $site_id = get_post_meta( $post_id, 'global_media_site_id', true );
+    if ( empty( $site_id ) ) {
+        $site_id = get_site_id();
+    }
+
     $id_prefix = get_site_id() . '00000';
 
     if (false !== strpos($thumbnail_id, $id_prefix)) {

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 _Multisite Global Media_ is a WordPress plugin which shares media across the Multisite network.
 
 ## Description
-This small plugin adds a new tab to the media modal which gives you the opportunity to share media from one site to all the other sites of the network. The `multisite-global-media.php` file uses the ID of the site that will store the global media. Currently the Site ID is set at `const SITE_ID = 3`. Change this value to set one of the other sites as the default for storing global media. You can also set/change this Site ID via filter hook `global_media.site_id`, like
+This small plugin adds a new tab to the media modal which gives you the opportunity to share media from one site to all the other sites of the network. The `multisite-global-media.php` file uses the ID of the site that will store the global media. Currently the Site ID is set at `const SITE_ID = 1`. Change this value to set one of the other sites as the default for storing global media. You can also set/change this Site ID via filter hook `global_media.site_id`, like
 
     add_filter( 'global_media.site_id', function() {
         return 1234;
@@ -23,13 +23,15 @@ To get Global Media to work one has to follow these steps:
   * @var    integer
   * @since  2015-01-22
   */
- const SITE_ID = 3;
+ const SITE_ID = 1;
  ```
 
 Normally you should not change the source. It is much easier for maintenance and other points. So if you are familiar with code in the WordPress context, use the hook below to change the default Site ID of the plugin with a small custom plugin.
 
 #### Hook for Site ID
-The plugin defines the hook `global_media.site_id` to set an ID for the network Site, that store the media files, like `add_filter( 'global_media.site_id', 1234 );`.
+The plugin defines the hook `global_media.site_id` to set an ID for the network Site, that store the media files, like `add_filter( 'global_media.site_id', function() {
+        return 1234;
+    } );`.
 
 ### Installation
 * Download the plugin as zip, use a clone of the repo or use Composer, see below
@@ -46,7 +48,7 @@ The plugin is also available as [Composer package](https://packagist.org/package
  ![Media Modal](./assets/screenshot-1.png)
 
  ![Usage in Featured Image](./assets/screenshot-2.png)
- 
+
 ## Other Notes
 
 ### Crafted by [Inpsyde](https://inpsyde.com) &middot; Engineering the web since 2006.


### PR DESCRIPTION
This changes will:

[x] fix missing site id on some cases
[x] fix warning on missing key for `_thumbnail_id` when saving
[x] set a new default for site ID for `1`
[x] improve and correct documentation


The reason for changing site_ID to 1, is to reduce the need to change and/or add the filter, as most cases, we've been always using site 1 as the main site. If there's other reasoning for having this random `3`, i can revert it.

found this reply from 2015, https://github.com/bueltge/multisite-global-media/issues/1#issuecomment-76378635 regarding the choice for SITE_ID 2. but its 3 ?