### PR TITLE
Admin post thumbnail won't set correctly because of switching blog

### DIFF
--- a/multisite-global-media.php
+++ b/multisite-global-media.php
@@ -350,12 +350,13 @@ function adminPostThumbnailHtml(string $content, int $postId, $thumbnailId): str
         return $content;
     }
 
+    $post = get_post($postId);
     $thumbnailId = (int)str_replace($idPrefix, '', $thumbnailId); // Unique ID, must be a number.
 
     switch_to_blog($siteId);
 
     // $thumbnailId is passed instead of postId to avoid warning messages of nonexistent post object.
-    $content = _wp_post_thumbnail_html($thumbnailId, $postId);
+    $content = _wp_post_thumbnail_html($thumbnailId, $post);
 
     restore_current_blog();
 


### PR DESCRIPTION
When we switch blog in function `adminPostThumbnailHtml` and we call
`_wp_post_thumbnail_html` by passing the `$postId` internally the post
build by the id will be null because that post doesn't exists in the
switched blog.

See pull request #43 for more informations

#8 