### PR TITLE
Fix query-attachments casting ids to strings causing blocks to invalidate

### DIFF
--- a/src/Attachment.php
+++ b/src/Attachment.php
@@ -47,7 +47,7 @@ class Attachment
     {
         $idPrefix = $this->site->idSitePrefix();
 
-        $response['id'] = $idPrefix.$response['id']; // Unique ID, must be a number.
+        $response['id'] = intval($idPrefix.$response['id']); // Unique ID, must be a number.
         $response['nonces']['update'] = false;
         $response['nonces']['edit'] = false;
         $response['nonces']['delete'] = false;

--- a/src/RestController.php
+++ b/src/RestController.php
@@ -85,8 +85,8 @@ class RestController extends WP_REST_Attachments_Controller
             return parent::get_item($request);
         }
 
-        $attachmentId = $request['id'];
-        $request['id'] = $this->stripSiteIdPrefixFromAttachmentId($idPrefix, (int) $attachmentId);
+        $attachmentId = (int) $request['id'];
+        $request['id'] = $this->stripSiteIdPrefixFromAttachmentId($idPrefix, $attachmentId);
         $this->siteSwitcher->switchToBlog($this->site->id());
         $response = parent::get_item($request);
         $data = $response->get_data();


### PR DESCRIPTION
Not sure how I missed this.

The bug is that when the media browser queries for all global media attachments, the integer ids are cast to strings and saved in block attributes as such. This causes the attribute to be dropped when the block is read as the value is [supposed to be an integer](https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/media-text/block.json#L27).