### PR TITLE
Restore Blog after Response

### DIFF
--- a/src/Rest/RestController.php
+++ b/src/Rest/RestController.php
@@ -97,6 +97,7 @@ class RestController extends WP_REST_Attachments_Controller
         $this->siteSwitcher->switchToBlog($this->site->id());
         $response = parent::get_item($request);
         $data = $response->get_data();
+        $this->siteSwitcher->restoreBlog();
 
         if (isset($data['id'])) {
             $data['id'] = $attachmentId;


### PR DESCRIPTION
There is a `$this->siteSwitcher->restoreBlog();` missing which leads to missing featured media for the following items