### PR TITLE
Fix "Cannot use object of type Closure as array"

### DIFF
--- a/src/Rest/Rest.php
+++ b/src/Rest/Rest.php
@@ -73,7 +73,7 @@ class Rest
     public function restRequestAfterCallbacks($response, array $handler, WP_REST_Request $request)
     {
         // phpcs:enable
-        if (!isset($handler['callback'][0]) || !($handler['callback'][0] instanceof WP_REST_Posts_Controller)) {
+        if (!is_array($handler['callback']) || !isset($handler['callback'][0]) || !($handler['callback'][0] instanceof WP_REST_Posts_Controller)) {
             return $response;
         }
 


### PR DESCRIPTION
"Cannot use object of type Closure as array" error when used with the "Site Kit by Google" plugin.

This seems to be caused by a closure returning to $handler['callback'].

I fixed it, so please review it.