### PR TITLE
ACF Image Support

### DIFF
--- a/src/ACF/Image.php
+++ b/src/ACF/Image.php
@@ -1,0 +1,54 @@
+<?php # -*- coding: utf-8 -*-
+
+namespace MultisiteGlobalMedia\ACF;
+
+use MultisiteGlobalMedia\Helper;
+use MultisiteGlobalMedia\SingleSwitcher;
+use MultisiteGlobalMedia\Site;
+
+class Image
+{
+
+    use Helper;
+
+    /**
+     * @var Site
+     */
+    private $site;
+
+    /**
+     * @var SingleSwitcher
+     */
+    private $siteSwitcher;
+
+    /**
+     * Image constructor
+     *
+     * @param Site $site
+     * @param SingleSwitcher $siteSwitcher
+     */
+    public function __construct(Site $site, SingleSwitcher $siteSwitcher){
+        $this->site = $site;
+        $this->siteSwitcher = $siteSwitcher;
+        $this->store = acf_get_store( 'values' );
+    }
+
+    // Fetch ACF file fields across sites when the global prefix is used.
+    // We hook into 'load_value' which usually runs just before 'format_value'.
+    // Then get the formatted output of the field in the global media site's context,
+    // and store it in ACF's cache. So when format_value tries to use this value,
+    // it will find the formatted one already in the cache.
+    // This works around acf_format_value requiring a valid att ID as input, but
+    // returning a string/array as output, so it can't be easily filtered.
+    public function acf_load_value( $value, $post_id, $field ) {
+        if ( $this->idPrefixIncludedInAttachmentId( (int)$value, $this->site->idSitePrefix() ) ) {
+            $formatted = $this->stripSiteIdPrefixFromAttachmentId( $this->site->idSitePrefix(), $value );
+            $this->siteSwitcher->switchToBlog( $this->site->id() );
+            $formatted = acf_format_value( $formatted, $post_id, $field );
+            $this->siteSwitcher->restoreBlog();
+            $this->store->set( "$post_id:{$field['name']}:formatted", $formatted );
+        }
+        // This filter doesn't modify the loaded value. Return it as-is.
+        return $value;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -56,9 +56,14 @@ class Plugin
 
         add_filter('register_post_type_args', [$rest, 'registerPostTypeArgs'], 10, 2);
         add_filter('rest_request_after_callbacks', [$rest, 'restRequestAfterCallbacks'], 10, 3);
+        
 
         if (\function_exists('wc')) {
             $this->wcBootstrap($site, $singleSwitcher);
+        }
+
+        if (\function_exists('acf')) {
+            $this->acfBootstrap($site, $singleSwitcher);
         }
     }
 
@@ -74,5 +79,18 @@ class Plugin
 
         add_action('woocommerce_new_product', [$wooCommerceGallery, 'saveGalleryIds']);
         add_action('woocommerce_update_product', [$wooCommerceGallery, 'saveGalleryIds']);
+    }
+
+    /**
+     * Integration for ACF, specifically Image fields
+     *
+     * @param Site $site
+     * @param SingleSwitcher $siteSwitcher
+     */
+    public function acfBootstrap(Site $site, SingleSwitcher $siteSwitcher)
+    {
+        $acfImage = new ACF\Image($site, $siteSwitcher);
+
+        add_filter('acf/load_value/type=image', array($acfImage, 'acf_load_value'), 10, 3);
     }
 }


### PR DESCRIPTION
I have minor experience in plugin development, so I'm happy to address any suggestions or methods in writing this better/more efficiently.

I'm aiming to use this plugin in production with a site that utilizes ACF heavily, including image fields. I found #86 in searching for answers to using Global Media with ACF and thought it might be nice to package that solution with the plugin itself (much like the WooCommerce Gallery class).

All credit goes to @mrazzari in his [solution](https://github.com/bueltge/multisite-global-media/issues/86#issuecomment-509817486).