### PR TITLE
fix: PHP 8.1 deprecated notices (missing return type declarations)

### DIFF
--- a/src/PluginProperties.php
+++ b/src/PluginProperties.php
@@ -102,7 +102,7 @@ class PluginProperties implements \ArrayAccess
      * @return mixed
      * @throws \OutOfRangeException If there is no property with the given name.
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if (!$this->offsetExists($offset)) {
             throw new \OutOfRangeException("'{$offset}' is not a valid plugin property.");
@@ -118,7 +118,7 @@ class PluginProperties implements \ArrayAccess
      *
      * @throws \BadMethodCallException
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         throw new \BadMethodCallException(
             __METHOD__ . ' is not allowed. ' . __CLASS__ . ' is read only.'
@@ -132,7 +132,7 @@ class PluginProperties implements \ArrayAccess
      *
      * @throws \BadMethodCallException
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         throw new \BadMethodCallException(
             __METHOD__ . ' is not allowed. ' . __CLASS__ . ' is read only.'


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
PHP 8.1 compatibility („Bug Fix“)


**What is the current behavior?** (You can also link to an open issue here)
Running the current version in a PHP 8.1 environment (WP_DEBUG enabled) shows deprecated messages:

`Deprecated: Return type of MultisiteGlobalMedia\PluginProperties::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/web/app/mu-plugins/multisite-global-media/src/PluginProperties.php on line 105

Deprecated: Return type of MultisiteGlobalMedia\PluginProperties::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/web/app/mu-plugins/multisite-global-media/src/PluginProperties.php on line 121

Deprecated: Return type of MultisiteGlobalMedia\PluginProperties::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/web/app/mu-plugins/multisite-global-media/src/PluginProperties.php on line 135`


**What is the new behavior (if this is a feature change)?**
By adding the missing return type declarations the notices will be gone.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Successfully tested on PHP 7.4, 8.0, 8.1.